### PR TITLE
Add default implementations of IClock

### DIFF
--- a/source/Octopus.Time/FixedClock.cs
+++ b/source/Octopus.Time/FixedClock.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Octopus.Time
+{
+    public class FixedClock : IClock
+    {
+        private DateTimeOffset now;
+
+        public FixedClock(DateTimeOffset now) => this.now = now;
+
+        public void Set(DateTimeOffset value) => this.now = value;
+
+        public void WindForward(TimeSpan time) => this.now = this.now.Add(time);
+
+        public DateTimeOffset GetUtcTime() => this.Clone().now.ToUniversalTime();
+
+        public DateTimeOffset GetLocalTime() => this.Clone().now.ToLocalTime();
+
+        private FixedClock Clone() => (FixedClock) this.MemberwiseClone();
+    }
+}

--- a/source/Octopus.Time/SystemClock.cs
+++ b/source/Octopus.Time/SystemClock.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Octopus.Time
+{
+    public class SystemClock : IClock
+    {
+        public DateTimeOffset GetUtcTime() => DateTimeOffset.UtcNow;
+
+        public DateTimeOffset GetLocalTime() => DateTimeOffset.Now;
+    }
+}


### PR DESCRIPTION
So we don't have to copy them round everywhere

Copied from Shared as at https://github.com/OctopusDeploy/OctopusShared/blob/c0b8f82aeac54e79cbba76bec9901378491c67f8/source/Octopus.Shared/Time/FixedClock.cs.

Relies on #9 being merged first.

Reviewer note:
This library previously contained only contracts... But it seemed less than ideal to keep copying round the implementations when they're unlikely to change much. Is there a better approach here?

Once merged:
* pull this change into Server/Tentacle
* remove the implementations from Shared.
* pull this change into ReleaseBot
* consider pulling the change into Octofront (though I think there are some different things happening over there around nodatime)
