### PR TITLE
Bump to include net5 package

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "5.0.3",
+        "rollForward": "latestFeature"
+    }
+}

--- a/source/Octopus.Time/Octopus.Time.csproj
+++ b/source/Octopus.Time/Octopus.Time.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net40;net452;net5.0</TargetFrameworks>
     <PackageIcon>icon.png</PackageIcon>
     <AssemblyName>Octopus.Time</AssemblyName>
     <PackageId>Octopus.Time</PackageId>


### PR DESCRIPTION
As requested [here](https://github.com/OctopusDeploy/Time/pull/8#pullrequestreview-590090166)

Note: this drops support for netstandard1.0, as that didn't want to build locally for me with net5.