### PR TITLE
NET6 Upgrade

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.3",
+        "version": "6.0.300",
         "rollForward": "latestFeature"
     }
 }

--- a/source/Octopus.Time/Octopus.Time.csproj
+++ b/source/Octopus.Time/Octopus.Time.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net40;net452;net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageIcon>icon.png</PackageIcon>
     <AssemblyName>Octopus.Time</AssemblyName>
     <PackageId>Octopus.Time</PackageId>
@@ -13,12 +13,6 @@
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>


### PR DESCRIPTION
Updated `_build.proj` target framework to `net6.0`
Removed redundant target framework in `Octopus.Time.proj`, is now targeting only `netstandard2.0`
Updated `global.json` sdk version to `6.0.300`
